### PR TITLE
Add support for using existing Cognitive Services Account

### DIFF
--- a/Create-Environment.ps1
+++ b/Create-Environment.ps1
@@ -45,6 +45,10 @@ $parameters = @{
         channelId = $settingsJson.DiscordChannelId
         guildId   = $settingsJson.DiscordGuildId
     }
+    cognitiveService       = @{
+        existingServiceName          = $settingsJson.ExistingCognitiveServicesAccountName
+        existingServiceResourceGroup = $settingsJson.ExistingCognitiveServicesResourceGroup
+    }
 }
 New-AzResourceGroupDeployment `
     -ResourceGroupName $settingsJson.ResourceGroup `

--- a/Create-Environment.ps1
+++ b/Create-Environment.ps1
@@ -13,7 +13,8 @@
 #>
 param(
     [Parameter()][string]$SettingsFile = 'developer-settings.json',
-    [Parameter()][switch]$NoDiscord
+    [Parameter()][switch]$NoDiscord,
+    [Parameter()][switch]$DeleteOldRoleAssingments
 )
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
@@ -34,6 +35,13 @@ else {
 
 Write-Host 'Creating resource group if it doesn''t exist...'
 New-AzResourceGroup -Name $settingsJson.ResourceGroup -Location $settingsJson.Location -Force
+
+if ($DeleteOldRoleAssingments -and -not [string]::IsNullOrEmpty($settingsJson.ExistingCognitiveServicesAccountName)) {
+    Write-Host 'Removing unknown ''Cognitive Services User'' role assignments...'
+    
+    $rg = $settingsJson.ExistingCognitiveServicesResourceGroup ?? $settingsJson.ResourceGroup
+    Remove-UnknownRoleAssingments -ResourceName $settingsJson.ExistingCognitiveServicesAccountName -ResourceGroupName $rg
+}
 
 Write-Host 'Deploying template...'
 $parameters = @{

--- a/developer-settings-sample.json
+++ b/developer-settings-sample.json
@@ -1,9 +1,11 @@
 {
-    "ResourceGroup": "",
-    "ApplicationName": "",
-    "Location": "North Europe",
-    "DiscordToken": "",
-    "DiscordGuildId": 0,
-    "DiscordChannelId": 0,
-    "Tags": []
+  "ResourceGroup": "",
+  "ApplicationName": "",
+  "Location": "North Europe",
+  "DiscordToken": "",
+  "DiscordGuildId": 0,
+  "DiscordChannelId": 0,
+  "ExistingCognitiveServicesAccountName": "existing-account-name",
+  "ExistingCognitiveServicesResourceGroup": "existing-resource-group-name",
+  "Tags": []
 }

--- a/infra/functions.bicep
+++ b/infra/functions.bicep
@@ -27,6 +27,9 @@ param identityName string
 @description('Cognitive services account name.')
 param cognitiveServicesAccountName string
 
+@description('Resource group of the cognitive services account.')
+param cognitiveServicesAccountResourceGroup string
+
 var hostingPlanName = 'asp-${baseName}'
 var functionAppName = 'func-${baseName}'
 var storageBlobDataOwnerRoleDefinitionId = 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'
@@ -48,7 +51,7 @@ resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-07-31-p
 
 resource cognitiveServiceAccount 'Microsoft.CognitiveServices/accounts@2023-05-01' existing = {
   name: cognitiveServicesAccountName
-  scope: resourceGroup()
+  scope: resourceGroup(cognitiveServicesAccountResourceGroup)
 }
 
 resource functionStorageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' = {

--- a/infra/image-analyzer-permissions.bicep
+++ b/infra/image-analyzer-permissions.bicep
@@ -1,0 +1,39 @@
+/*
+ * Create a role assignment to assign the Cognitive Services User role to the given User Assigned Identities.
+ * This should be deployed to the resource group where Cognitive Services Account is. Identities can be in
+ * a different resource group.
+ */
+
+@description('Name of the Cognitive Services account.')
+param cognitiveServiceName string
+
+@description('Identities of which are assigned with Blob Data Reader to the containers.')
+param cognitiveServiceUserIdentityName string
+param cognitiveServiceUserIdentityResourceGroup string
+
+var cognitiveServicesUserRoleDefinitionId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  'a97b65f3-24c7-4388-baec-2e87135dc908'
+)
+
+resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-07-31-preview' existing = {
+  name: cognitiveServiceUserIdentityName
+  scope: resourceGroup(cognitiveServiceUserIdentityResourceGroup)
+}
+
+resource cognitiveServiceAccount 'Microsoft.CognitiveServices/accounts@2023-05-01' existing = {
+  name: cognitiveServiceName
+  scope: resourceGroup()
+}
+
+resource cognitiveServiceAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: cognitiveServiceAccount
+  name: guid(identity.id, cognitiveServicesUserRoleDefinitionId, cognitiveServiceAccount.id)
+  properties: {
+    principalId: identity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: cognitiveServicesUserRoleDefinitionId
+  }
+}
+
+output cognitiveServiceAccountName string = cognitiveServiceAccount.name

--- a/infra/image-analyzer-resolver.bicep
+++ b/infra/image-analyzer-resolver.bicep
@@ -1,0 +1,51 @@
+import { CognitiveServiceSettings } from 'types.bicep'
+
+/*
+ * Either creates a new CognitiveService account or uses an existing one.
+ * and adds the necessary permissions to the user identity.
+ * This is seprate module because the existing CognitiveService account
+ * may be in a different resource group (scope).
+ */
+
+@minLength(5)
+param baseName string
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+@description('Settings for deciding which CognitiveService resource is used.')
+param cognitiveService CognitiveServiceSettings
+
+@description('Identities of which are assigned with Blob Data Reader to the containers.')
+param cognitiveServiceUserIdentityName string
+
+// NOTE: ?? ''  - is used to circument type warnings.
+var existingServiceResourceGroupName = cognitiveService.existingServiceResourceGroup ?? ''
+var getExisting = cognitiveService.existingServiceName != null
+
+resource old 'Microsoft.CognitiveServices/accounts@2023-05-01' existing = if (getExisting) {
+  name: cognitiveService.existingServiceName ?? ''
+  scope: resourceGroup(existingServiceResourceGroupName)
+}
+
+module rbacAssingments 'image-analyzer-permissions.bicep' = if (getExisting) {
+  scope: resourceGroup(existingServiceResourceGroupName)
+  name: 'cognitiveServiceUser-old'
+  params: {
+    cognitiveServiceName: old.name
+    cognitiveServiceUserIdentityName: cognitiveServiceUserIdentityName
+    cognitiveServiceUserIdentityResourceGroup: resourceGroup().name
+  }
+}
+
+module new 'image-analyzer.bicep' = if (!getExisting) {
+  name: 'newAnalyzer'
+  params: {
+    baseName: baseName
+    location: location
+    cognitiveServiceUserIdentityNames: [cognitiveServiceUserIdentityName]
+  }
+}
+
+output cognitiveServiceAccountName string = getExisting ? old.name : new.outputs.cognitiveServiceAccountName
+output cognitiveServiceResourceGroup string = getExisting ? existingServiceResourceGroupName : resourceGroup().name

--- a/infra/image-storage.bicep
+++ b/infra/image-storage.bicep
@@ -17,8 +17,9 @@ resource identities 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-07-31
   }
 ]
 
+var storageName = replace('stimages${baseName}', '-', '')
 resource imageStorage 'Microsoft.Storage/storageAccounts@2022-05-01' = {
-  name: substring(replace('stimages${baseName}', '-', ''), 0, 24)
+  name: substring(storageName, 0, min(length(storageName), 24))
   location: location
   kind: 'StorageV2'
   sku: {

--- a/infra/types.bicep
+++ b/infra/types.bicep
@@ -21,3 +21,13 @@ type SecretKeyValue = {
   @secure()
   value: string
 }
+
+@description('Settings for deciding which CognitiveService resource is used.')
+@export()
+type CognitiveServiceSettings = {
+  @description('The name of the CognitiveService resource. If null, a new resource is created.')
+  existingServiceName: string?
+
+  @description('The resource group of the existing CognitiveService resource. If null, current resource group is used.')
+  existingServiceResourceGroup: string?
+}

--- a/scripts/FunctionUtil.ps1
+++ b/scripts/FunctionUtil.ps1
@@ -86,3 +86,32 @@ function Get-FunctionBaseUrl() {
     )
     return "https://$($FunctionApp.HostNames[0])/api/"
 }
+
+<#
+    .SYNOPSIS
+    Removes unknown 'Cognitive Services User' assignments from the
+    Cognitive Services resource.
+
+    .DESCRIPTION
+    This is a support script for deployment. When Resource Assignment ID is
+    generated in image-analyzer-permissions.bicep, it uses the identity ID as
+    part of deployment ID. This can cause problems, because the principal ID is
+    different if the identity resource is recreated, but the resource ID is
+    the same.
+#>
+function Remove-UnknownRoleAssingments() {
+    param(
+        [Parameter(Mandatory)][string]$ResourceName,
+        [Parameter(Mandatory)][string]$ResourceGroupName
+    )
+    $resourceType = 'Microsoft.CognitiveServices/accounts'
+    $roleDefinitionName = 'Cognitive Services User'
+    Write-Host "Removing unknown 'Cognitive Services User' role assignments from Resource Group '$ResourceGroupName' resource '$ResourceName'..."
+    Get-AzRoleAssignment `
+        -ResourceName $ResourceName `
+        -ResourceGroupName $ResourceGroupName `
+        -ResourceType $resourceType `
+        -RoleDefinitionName $roleDefinitionName `
+    | Where-Object { $_.ObjectType -eq 'Unknown' } `
+    | Remove-AzRoleAssignment
+}

--- a/scripts/Get-ImageIndex.ps1
+++ b/scripts/Get-ImageIndex.ps1
@@ -1,0 +1,27 @@
+<#
+    .SYNOPSIS
+    This script builds and publishes measurement listener to Azure
+
+    .DESCRIPTION
+    This assumes that dotnet sdk and Azure Powershell are installed
+
+    .PARAMETER SettinsFile
+    Settings file that contains environment settings. Defaults to 'developer-settings.json'
+#>
+param(
+    [Parameter()][string]$SettingsFile = 'developer-settings.json'
+)
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+.$PSScriptRoot/FunctionUtil.ps1
+
+$settingsJson = Get-DeveloperSettings -SettingsFile $SettingsFile
+$appName = "func-$($settingsJson.ResourceGroup)"
+
+$webApp = Get-AzWebApp -ResourceGroupName $settingsJson.ResourceGroup -Name $appName
+$url = Get-FunctionBaseUrl -FunctionApp $webApp
+$code = Get-FunctionCode -FunctionApp $webApp
+
+$functionUrl = "$($url)GetImageIndex?code=$code"
+Invoke-RestMethod -Method Get -Uri $functionUrl -ContentType 'application/json'

--- a/src/Common/ImageAnalysis/IImageAnalysisService.cs
+++ b/src/Common/ImageAnalysis/IImageAnalysisService.cs
@@ -6,9 +6,9 @@ namespace DiscordImagePoster.Common.ImageAnalysis;
 public interface IImageAnalysisService
 {
     /// <summary>
-    /// Analyzes the image in stream.
+    /// Analyzes the image provided in BinaryData.
     /// </summary>
-    /// <param name="stream">The stream containing the image.</param>
-    /// <returns>The analysis results.</returns>
-    Task<ImageAnalysisResults> AnalyzeImageAsync(Stream stream);
+    /// <param name="binaryData">The BinaryData containing the image.</param>
+    /// <returns>The analysis results. Can be null if image analysis is not done.</returns>
+    Task<ImageAnalysisResults?> AnalyzeImageAsync(BinaryData binaryData);
 }

--- a/src/Common/ImageAnalysis/ImageAnalysisService.cs
+++ b/src/Common/ImageAnalysis/ImageAnalysisService.cs
@@ -21,10 +21,10 @@ public class ImageAnalysisService : IImageAnalysisService
     }
 
     /// <inheritdoc/>
-    public async Task<ImageAnalysisResults> AnalyzeImageAsync(Stream stream)
+    public async Task<ImageAnalysisResults?> AnalyzeImageAsync(BinaryData binaryData)
     {
         _logger.LogDebug("Analyzing image...");
-        var result = await _imageAnalysisClient.AnalyzeAsync(BinaryData.FromStream(stream), VisualFeatures.Caption | VisualFeatures.Tags);
+        var result = await _imageAnalysisClient.AnalyzeAsync(binaryData, VisualFeatures.Caption | VisualFeatures.Tags);
         var tags = result.Value.Tags.Values.Select(tag => $"{tag.Name} {tag.Confidence}").ToArray();
         _logger.LogDebug("Image analysis result with caption: {result}, and tags {tags}", result.Value.Caption.Text, tags);
         _logger.LogTrace("Image analysis result: {result}", JsonSerializer.Serialize(result));

--- a/src/Common/ImageAnalysis/NoOpImageAnalysisService.cs
+++ b/src/Common/ImageAnalysis/NoOpImageAnalysisService.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Logging;
+
+namespace DiscordImagePoster.Common.ImageAnalysis;
+
+public class NoOpImageAnalysisService : IImageAnalysisService
+{
+    public NoOpImageAnalysisService(ILogger<NoOpImageAnalysisService> logger)
+    {
+    }
+
+    public Task<ImageAnalysisResults?> AnalyzeImageAsync(BinaryData binaryData)
+    {
+        return Task.FromResult<ImageAnalysisResults?>(null);
+    }
+}

--- a/src/FunctionApp.Isolated/FeatureSettings.cs
+++ b/src/FunctionApp.Isolated/FeatureSettings.cs
@@ -12,6 +12,11 @@ public class FeatureSettings
     public bool DisableTimedSending { get; set; }
 
     /// <summary>
+    /// If true, the function will not analyze images.
+    /// </summary>
+    public bool DisableImageAnalysis { get; set; }
+
+    /// <summary>
     /// If true, the function will not send to discord
     /// This is mostly used for debugging purposes.
     /// </summary>

--- a/src/FunctionApp.Isolated/Functions/ImageSendFunction.cs
+++ b/src/FunctionApp.Isolated/Functions/ImageSendFunction.cs
@@ -82,22 +82,22 @@ public class ImageSendFunction
         var result = await _imageService.GetImageStream(randomImage.Name);
         if (result is null)
         {
-            _logger.LogError("No image found");
+            _logger.LogError("No image found.");
             return;
         }
 
         var binaryData = BinaryData.FromStream(result.Content);
-        var analyzationResults = await _imageAnalysisService.AnalyzeImageAsync(binaryData.ToStream());
+        var analyzationResults = await _imageAnalysisService.AnalyzeImageAsync(binaryData);
 
-        _logger.LogInformation("Sending image {ImageName} with caption {Caption} and tags {Tags}", randomImage.Name, analyzationResults.Caption, string.Join(", ", analyzationResults.Tags));
+        _logger.LogInformation("Sending image {ImageName} with caption {Caption} and tags {Tags}", randomImage.Name, analyzationResults?.Caption, string.Join(", ", analyzationResults?.Tags ?? Array.Empty<string>()));
         var imageMetadata = new ImageMetadataUpdate
         {
             Name = randomImage.Name,
-            Caption = analyzationResults.Caption,
-            Tags = analyzationResults.Tags
+            Caption = analyzationResults?.Caption,
+            Tags = analyzationResults?.Tags
         };
 
-        await _discordImagePoster.SendImage(binaryData.ToStream(), randomImage.Name, analyzationResults.Caption);
+        await _discordImagePoster.SendImage(binaryData.ToStream(), randomImage.Name, analyzationResults?.Caption ?? randomImage.Name);
 
         await _indexService.IncreasePostingCountAndUpdateMetadataAsync(imageMetadata);
     }

--- a/src/FunctionApp.Isolated/Program.cs
+++ b/src/FunctionApp.Isolated/Program.cs
@@ -28,7 +28,15 @@ var host = new HostBuilder()
             var options = services.GetRequiredService<IOptions<ImageAnalysisConfiguration>>().Value;
             return new ImageAnalysisClient(new Uri(options.Endpoint), new DefaultAzureCredential());
         });
-        services.AddTransient<IImageAnalysisService, ImageAnalysisService>();
+        services.AddTransient<IImageAnalysisService>(services =>
+        {
+            var options = services.GetRequiredService<IOptions<FeatureSettings>>().Value;
+            return
+                options.DisableImageAnalysis ?
+                new NoOpImageAnalysisService(services.GetRequiredService<ILogger<NoOpImageAnalysisService>>())
+                :
+                new ImageAnalysisService(services.GetRequiredService<ILogger<ImageAnalysisService>>(), services.GetRequiredService<ImageAnalysisClient>());
+        });
 
         services.AddTransient<IDiscordImagePoster>(services =>
         {


### PR DESCRIPTION
We want to use the free tier Cognitive Services for developing, but there can be only one existing at the time, we need to support using existing Cognitive Services Account.