### PR TITLE
Make build-iac manual for testing

### DIFF
--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -1,14 +1,15 @@
 name: Build and test infrastructure
 
-on:
-  push:
-    branches: [ "main" ]
-    paths:
-      - "infra/*.bicep"
-  pull_request:
-    branches: [ "main" ]
-    paths:
-      - "infra/*.bicep"
+on: workflow_dispatch
+  
+  #push:
+  #  branches: [ "main" ]
+  #  paths:
+  #    - "infra/*.bicep"
+  #pull_request:
+  #  branches: [ "main" ]
+  #  paths:
+  #    - "infra/*.bicep"
 
 jobs:
   build:


### PR DESCRIPTION
Make build-iac manual for testing because otherwise workflows can't be easily started.