### PR TITLE
Add IAC testing pipeline

### DIFF
--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  RESOURCE_GROUP: dip-iactest-${{ env.GITHUB_RUN_ID }}
+  RESOURCE_GROUP: dip-iactest-${{ github.run_id }}
   COGNITIVE_SERVICES_ACCOUNT_NAME: aisa-hjni-discord-image-poster
   COGNITIVE_SERVICES_RESOURCEGROUP: hjni-discord-image-poster
 

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -64,29 +64,20 @@ jobs:
         azPSVersion: "latest"
         inlineScript: |
           # Remove role assingments
-          $displayName = "id-$($env:RESOURCE_GROUP)"
-          Write-Host $displayName
+          $idResourceGroupName = "$($env:RESOURCE_GROUP)"
+          $idName = "id-$($env:RESOURCE_GROUP)"
+          Write-Host $idName
           $accountName = $env:COGNITIVE_SERVICES_ACCOUNT_NAME
           Write-Host $accountName
-          $resourceGroup = $env:COGNITIVE_SERVICES_RESOURCEGROUP
-          Write-Host $resourceGroup
+          $cognitiveServicesResourceGroupName = $env:COGNITIVE_SERVICES_RESOURCEGROUP
+          Write-Host $cognitiveServicesResourceGroupName
+
+          $cognitiveServices = Get-AzCognitiveServicesAccount -ResourceGroupName $cognitiveServicesResourceGroupName -AccountName $accountName
+          $identity = Get-AzUserAssignedIdentity -Name $idName -ResourceGroupName $idResourceGroupName
 
           Get-AzRoleAssignment `
-            -ResourceName $accountName `
-            -ResourceType 'Microsoft.CognitiveServices/accounts' `
-            -ResourceGroupName $resourceGroup 
-
-          Get-AzRoleAssignment `
-            -ResourceName $accountName `
-            -ResourceType 'Microsoft.CognitiveServices/accounts' `
-            -ResourceGroupName $resourceGroup `
-          | Where-Object { $_.DisplayName -eq $displayName }
-
-          Get-AzRoleAssignment `
-            -ResourceName $accountName `
-            -ResourceType 'Microsoft.CognitiveServices/accounts' `
-            -ResourceGroupName $resourceGroup `
-          | Where-Object { $_.DisplayName -eq $displayName } `
+            -Scope $cognitiveServices.Id `
+            -ObjectId $identity.PrincipalId `
           | Remove-AzRoleAssignment
 
           # Delete resource group

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -15,6 +15,11 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  RESOURCE_GROUP: dip-iactest-${{ env.GITHUB_RUN_ID }}
+  COGNITIVE_SERVICES_ACCOUNT_NAME: aisa-hjni-discord-image-poster
+  COGNITIVE_SERVICES_RESOURCEGROUP: hjni-discord-image-poster
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -40,14 +45,14 @@ jobs:
         inlineScript: |
           $settingsPath = Join-Path -Path (Resolve-Path ".\").Path -ChildPath 'test-infra-settings.json'
           $settings = @{
-            ResourceGroup = "dip-iactest-$($env:GITHUB_RUN_ID)"
-            ApplicationName = "dip-iactest-$($env:GITHUB_RUN_ID)"
+            ResourceGroup = $env:RESOURCE_GROUP
+            ApplicationName = $env:RESOURCE_GROUP
             Location = "North Europe"
             DiscordToken = 'mock token'
             DiscordGuildId = 0
             DiscordChannelId = 0
-            ExistingCognitiveServicesAccountName = "aisa-hjni-discord-image-poster"
-            ExistingCognitiveServicesResourceGroup = "hjni-discord-image-poster"
+            ExistingCognitiveServicesAccountName = $env:COGNITIVE_SERVICES_ACCOUNT_NAME
+            ExistingCognitiveServicesResourceGroup = $env:COGNITIVE_SERVICES_RESOURCEGROUP
           }
           $settings | ConvertTo-Json | Set-Content -Path $settingsPath
 
@@ -58,4 +63,9 @@ jobs:
       with:
         azPSVersion: "latest"
         inlineScript: |
-          $resourceGroupName = "dip-iactest-$($env:GITHUB_RUN_ID)"
+          Get-AzRoleAssignment `
+            -ResourceName $env:COGNITIVE_SERVICES_ACCOUNT_NAME `
+            -ResourceType 'Microsoft.CognitiveServices/accounts' `
+            -ResourceGroupName $env:COGNITIVE_SERVICES_RESOURCEGROUP `
+          | Where-Object { $_.DisplayName -eq "id-$($env:RESOURCE_GROUP)" } `
+          | Remove-AzRoleAssignment

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -40,8 +40,8 @@ jobs:
         inlineScript: |
           $settingsPath = Join-Path -Path (Resolve-Path ".\").Path -ChildPath 'test-infra-settings.json'
           $settings = @{
-            ResourceGroup = "discord-image-iactest-$($env:GITHUB_RUN_ID)"
-            ApplicationName = "discord-image-iactest-$($env:GITHUB_RUN_ID)"
+            ResourceGroup = "dip-iactest-$($env:GITHUB_RUN_ID)"
+            ApplicationName = "dip-iactest-$($env:GITHUB_RUN_ID)"
             Location = "North Europe"
             DiscordToken = 'mock token'
             DiscordGuildId = 0
@@ -52,3 +52,10 @@ jobs:
           $settings | ConvertTo-Json | Set-Content -Path $settingsPath
 
           ./Create-Environment.ps1 -SettingsFile $settingsPath -NoDiscord
+    
+    - name: Cleanup
+      uses: azure/powershell@v2
+      with:
+        azPSVersion: "latest"
+        inlineScript: |
+          $resourceGroupName = "dip-iactest-$($env:GITHUB_RUN_ID)"

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -25,10 +25,10 @@ jobs:
       run: |
         $settingsPath = Join-Path -Path (Resolve-Path ".\").Path -ChildPath 'test-infra-settings.json'
         $settings = @{
-          ResourceGroup = $env:GITHUB_RUN_ID
-          ApplicationName = $env:GITHUB_RUN_ID
-          Location = "North Europe"
-          DiscordToken = 'mock token'
+          ResourceGroup = $env:GITHUB_RUN_ID,
+          ApplicationName = $env:GITHUB_RUN_ID,
+          Location = "North Europe",
+          DiscordToken = 'mock token',
           DiscordGuildId = 0,
           DiscordChannelId = 0,
           ExistingCognitiveServicesAccountName = "aisa-hjni-discord-image-poster",

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -66,10 +66,15 @@ jobs:
           # Remove role assingments
           $displayName = "id-$($env:RESOURCE_GROUP)"
           Write-Host $displayName
+          $accountName = $env:COGNITIVE_SERVICES_ACCOUNT_NAME
+          Write-Host $accountName
+          $resourceGroup = $env:COGNITIVE_SERVICES_RESOURCEGROUP
+          Write-Host $resourceGroup
+
           Get-AzRoleAssignment `
-            -ResourceName $env:COGNITIVE_SERVICES_ACCOUNT_NAME `
+            -ResourceName $accountName `
             -ResourceType 'Microsoft.CognitiveServices/accounts' `
-            -ResourceGroupName $env:COGNITIVE_SERVICES_RESOURCEGROUP `
+            -ResourceGroupName $resourceGroup `
           | Where-Object { $_.DisplayName -eq $displayName } `
           | Remove-AzRoleAssignment
 

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -13,11 +13,20 @@ on: workflow_dispatch
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    environment: ci-test
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Login via Az module
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        enable-AzPSSession: true 
+
     - name: Create settings file
       shell: pwsh
       env:

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -1,4 +1,4 @@
-name: Build and test infrastructure
+name: Build and Test Infrastructure
 
 on: workflow_dispatch
   
@@ -25,8 +25,8 @@ jobs:
       run: |
         $settingsPath = Join-Path -Path (Resolve-Path ".\").Path -ChildPath 'test-infra-settings.json'
         $settings = @{
-          ResourceGroup = $env:GITHUB_RUN_ID
-          ApplicationName = $env:GITHUB_RUN_ID
+          ResourceGroup = "discord-image-iactest-$($env:GITHUB_RUN_ID)"
+          ApplicationName = "discord-image-iactest-$($env:GITHUB_RUN_ID)"
           Location = "North Europe"
           DiscordToken = 'mock token'
           DiscordGuildId = 0
@@ -35,4 +35,5 @@ jobs:
           ExistingCognitiveServicesResourceGroup = "hjni-discord-image-poster"
         }
         $settings | ConvertTo-Json | Set-Content -Path $settingsPath
-        echo ($settings | ConvertTo-Json)
+
+        ./Create-Environment.ps1 -SettingsFile $settingsPath -NoDiscord

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -1,15 +1,16 @@
 name: Build and Test Infrastructure
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
   
-  #push:
-  #  branches: [ "main" ]
-  #  paths:
-  #    - "infra/*.bicep"
-  #pull_request:
-  #  branches: [ "main" ]
-  #  paths:
-  #    - "infra/*.bicep"
+  push:
+    branches: [ "main" ]
+    paths:
+      - "infra/*.bicep"
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - "infra/*.bicep"
 
 permissions:
   id-token: write
@@ -36,7 +37,7 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         enable-AzPSSession: true 
 
-    - name: Create settings file
+    - name: Create environment
       uses: azure/powershell@v2
       env:
         ARTIFACT_LOCATION: ${{ steps.package-zip.outputs.ARTIFACT_LOCATION }}

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -25,14 +25,14 @@ jobs:
       run: |
         $settingsPath = Join-Path -Path (Resolve-Path ".\").Path -ChildPath 'test-infra-settings.json'
         $settings = @{
-          "ResourceGroup" = $env:GITHUB_RUN_ID
-          "ApplicationName" = $env:GITHUB_RUN_ID
-          "Location" = "North Europe"
-          "DiscordToken" = 'mock token'
-          "DiscordGuildId" = 0,
-          "DiscordChannelId" = 0,
-          "ExistingCognitiveServicesAccountName" = "aisa-hjni-discord-image-poster",
-          "ExistingCognitiveServicesResourceGroup" = "hjni-discord-image-poster"
+          ResourceGroup = $env:GITHUB_RUN_ID
+          ApplicationName = $env:GITHUB_RUN_ID
+          Location = "North Europe"
+          DiscordToken = 'mock token'
+          DiscordGuildId = 0,
+          DiscordChannelId = 0,
+          ExistingCognitiveServicesAccountName = "aisa-hjni-discord-image-poster",
+          ExistingCognitiveServicesResourceGroup = "hjni-discord-image-poster"
         }
         $settings | ConvertTo-Json | Set-Content -Path $settingsPath
         echo ($settings | ConvertTo-Json)

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -18,8 +18,8 @@ permissions:
 
 env:
   RESOURCE_GROUP: dip-iactest-${{ github.run_id }}
-  COGNITIVE_SERVICES_ACCOUNT_NAME: aisa-hjni-discord-image-poster
-  COGNITIVE_SERVICES_RESOURCEGROUP: hjni-discord-image-poster
+  COGNITIVE_SERVICES_ACCOUNT_NAME: ${{ secrets.COGNITIVE_SERVICES_ACCOUNT_NAME }}
+  COGNITIVE_SERVICES_RESOURCEGROUP: ${{ secrets.COGNITIVE_SERVICES_RESOURCEGROUP }}
 
 jobs:
   build:

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -81,4 +81,4 @@ jobs:
           | Remove-AzRoleAssignment
 
           # Delete resource group
-          #Remove-AzResourceGroup -Name $env:RESOURCE_GROUP -Force
+          Remove-AzResourceGroup -Name $idResourceGroupName -Force

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -25,13 +25,13 @@ jobs:
       run: |
         $settingsPath = Join-Path -Path (Resolve-Path ".\").Path -ChildPath 'test-infra-settings.json'
         $settings = @{
-          ResourceGroup = $env:GITHUB_RUN_ID,
-          ApplicationName = $env:GITHUB_RUN_ID,
-          Location = "North Europe",
-          DiscordToken = 'mock token',
-          DiscordGuildId = 0,
-          DiscordChannelId = 0,
-          ExistingCognitiveServicesAccountName = "aisa-hjni-discord-image-poster",
+          ResourceGroup = $env:GITHUB_RUN_ID
+          ApplicationName = $env:GITHUB_RUN_ID
+          Location = "North Europe"
+          DiscordToken = 'mock token'
+          DiscordGuildId = 0
+          DiscordChannelId = 0
+          ExistingCognitiveServicesAccountName = "aisa-hjni-discord-image-poster"
           ExistingCognitiveServicesResourceGroup = "hjni-discord-image-poster"
         }
         $settings | ConvertTo-Json | Set-Content -Path $settingsPath

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -74,6 +74,17 @@ jobs:
           Get-AzRoleAssignment `
             -ResourceName $accountName `
             -ResourceType 'Microsoft.CognitiveServices/accounts' `
+            -ResourceGroupName $resourceGroup 
+
+          Get-AzRoleAssignment `
+            -ResourceName $accountName `
+            -ResourceType 'Microsoft.CognitiveServices/accounts' `
+            -ResourceGroupName $resourceGroup `
+          | Where-Object { $_.DisplayName -eq $displayName }
+
+          Get-AzRoleAssignment `
+            -ResourceName $accountName `
+            -ResourceType 'Microsoft.CognitiveServices/accounts' `
             -ResourceGroupName $resourceGroup `
           | Where-Object { $_.DisplayName -eq $displayName } `
           | Remove-AzRoleAssignment

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -11,6 +11,10 @@ on: workflow_dispatch
   #  paths:
   #    - "infra/*.bicep"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -74,4 +74,4 @@ jobs:
           | Remove-AzRoleAssignment
 
           # Delete resource group
-          Remove-AzResourceGroup -Name $env:RESOURCE_GROUP -Force
+          #Remove-AzResourceGroup -Name $env:RESOURCE_GROUP -Force

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -32,10 +32,12 @@ jobs:
         enable-AzPSSession: true 
 
     - name: Create settings file
-      shell: pwsh
+      uses: azure/powershell@v2
+      with:
+        azPSVersion: "latest"
       env:
         ARTIFACT_LOCATION: ${{ steps.package-zip.outputs.ARTIFACT_LOCATION }}
-      run: |
+      inlineScript: |
         $settingsPath = Join-Path -Path (Resolve-Path ".\").Path -ChildPath 'test-infra-settings.json'
         $settings = @{
           ResourceGroup = "discord-image-iactest-$($env:GITHUB_RUN_ID)"

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -33,22 +33,22 @@ jobs:
 
     - name: Create settings file
       uses: azure/powershell@v2
-      with:
-        azPSVersion: "latest"
       env:
         ARTIFACT_LOCATION: ${{ steps.package-zip.outputs.ARTIFACT_LOCATION }}
-      inlineScript: |
-        $settingsPath = Join-Path -Path (Resolve-Path ".\").Path -ChildPath 'test-infra-settings.json'
-        $settings = @{
-          ResourceGroup = "discord-image-iactest-$($env:GITHUB_RUN_ID)"
-          ApplicationName = "discord-image-iactest-$($env:GITHUB_RUN_ID)"
-          Location = "North Europe"
-          DiscordToken = 'mock token'
-          DiscordGuildId = 0
-          DiscordChannelId = 0
-          ExistingCognitiveServicesAccountName = "aisa-hjni-discord-image-poster"
-          ExistingCognitiveServicesResourceGroup = "hjni-discord-image-poster"
-        }
-        $settings | ConvertTo-Json | Set-Content -Path $settingsPath
+      with:
+        azPSVersion: "latest"
+        inlineScript: |
+          $settingsPath = Join-Path -Path (Resolve-Path ".\").Path -ChildPath 'test-infra-settings.json'
+          $settings = @{
+            ResourceGroup = "discord-image-iactest-$($env:GITHUB_RUN_ID)"
+            ApplicationName = "discord-image-iactest-$($env:GITHUB_RUN_ID)"
+            Location = "North Europe"
+            DiscordToken = 'mock token'
+            DiscordGuildId = 0
+            DiscordChannelId = 0
+            ExistingCognitiveServicesAccountName = "aisa-hjni-discord-image-poster"
+            ExistingCognitiveServicesResourceGroup = "hjni-discord-image-poster"
+          }
+          $settings | ConvertTo-Json | Set-Content -Path $settingsPath
 
-        ./Create-Environment.ps1 -SettingsFile $settingsPath -NoDiscord
+          ./Create-Environment.ps1 -SettingsFile $settingsPath -NoDiscord

--- a/.github/workflows/build-iac.yaml
+++ b/.github/workflows/build-iac.yaml
@@ -63,9 +63,15 @@ jobs:
       with:
         azPSVersion: "latest"
         inlineScript: |
+          # Remove role assingments
+          $displayName = "id-$($env:RESOURCE_GROUP)"
+          Write-Host $displayName
           Get-AzRoleAssignment `
             -ResourceName $env:COGNITIVE_SERVICES_ACCOUNT_NAME `
             -ResourceType 'Microsoft.CognitiveServices/accounts' `
             -ResourceGroupName $env:COGNITIVE_SERVICES_RESOURCEGROUP `
-          | Where-Object { $_.DisplayName -eq "id-$($env:RESOURCE_GROUP)" } `
+          | Where-Object { $_.DisplayName -eq $displayName } `
           | Remove-AzRoleAssignment
+
+          # Delete resource group
+          Remove-AzResourceGroup -Name $env:RESOURCE_GROUP -Force

--- a/infra/key-vault.bicep
+++ b/infra/key-vault.bicep
@@ -24,7 +24,7 @@ resource identities 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-07-31
   }
 ]
 
-var keyVaultName = replace('kv${baseName}', '-', '')
+var keyVaultName = 'kv${uniqueString(resourceGroup().id, baseName)}'
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: keyVaultName
   location: location


### PR DESCRIPTION
Adds pipeline which is triggered when changes are made to `*.bicep` files. This pipeline creates the infrastructure to Azure and cleans up afterwards. Purpose if this is to verify that the bicep can still be built.